### PR TITLE
Refatoração: Implementação de mapper e dto para ninja

### DIFF
--- a/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaController.java
+++ b/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaController.java
@@ -21,23 +21,23 @@ public class NinjaController {
     }
 
     @PostMapping("/criar")
-    public NinjaModel criarNinja(NinjaModel ninja){
+    public NinjaDTO criarNinja(@RequestBody NinjaDTO ninja){
         return ninjaService.criarNinja(ninja);
     }
 
     @GetMapping("/todos")
-    public List<NinjaModel> mostrarTodosOsNinjas(){
+    public List<NinjaDTO> mostrarTodosOsNinjas(){
         return ninjaService.mostrarTodosOsNinjas();
     }
 
     @GetMapping("/mostrar/{id}")
-    public Optional<NinjaModel> mostrarNinjaPorId(@PathVariable Long id){
+    public NinjaDTO mostrarNinjaPorId(@PathVariable Long id){
         return ninjaService.mostrarNinjaPorId(id);
     }
 
     @PutMapping("/atualizar/{id}")
-    public NinjaModel atualizarNinjaPorId(@PathVariable Long id, @RequestBody NinjaModel ninjaAtualizado){
-        return ninjaService.atualizarNinjaPorId(id, ninjaAtualizado);
+    public NinjaDTO atualizarNinjaPorId(@PathVariable Long id, @RequestBody NinjaDTO ninjaDTO){
+        return ninjaService.atualizarNinjaPorId(id, ninjaDTO);
     }
 
     @DeleteMapping("/deletar/{id}")

--- a/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaDTO.java
+++ b/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaDTO.java
@@ -1,0 +1,4 @@
+package dev.javath.cadastroNinjas.Ninjas;
+
+public class NinjaDTO {
+}

--- a/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaDTO.java
+++ b/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaDTO.java
@@ -1,4 +1,18 @@
 package dev.javath.cadastroNinjas.Ninjas;
 
+import dev.javath.cadastroNinjas.Missoes.MissoesModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class NinjaDTO {
+    private Long id;
+    private String nome;
+    private String cla;
+    private String rank;
+    private String tecnicas;
+    private MissoesModel missoes;
 }

--- a/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaMapper.java
+++ b/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaMapper.java
@@ -1,4 +1,31 @@
 package dev.javath.cadastroNinjas.Ninjas;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class NinjaMapper {
+
+    public NinjaModel map(NinjaDTO ninjaDTO){
+        NinjaModel ninjaModel = new NinjaModel();
+        ninjaModel.setId(ninjaDTO.getId());
+        ninjaModel.setNome(ninjaDTO.getNome());
+        ninjaModel.setCla(ninjaDTO.getCla());
+        ninjaModel.setRank(ninjaDTO.getRank());
+        ninjaModel.setTecnicas(ninjaDTO.getTecnicas());
+        ninjaModel.setMissoes(ninjaDTO.getMissoes());
+
+        return ninjaModel;
+    }
+
+    public NinjaDTO map (NinjaModel ninjaModel){
+        NinjaDTO ninjaDTO = new NinjaDTO();
+        ninjaDTO.setId(ninjaModel.getId());
+        ninjaDTO.setNome(ninjaModel.getNome());
+        ninjaDTO.setCla(ninjaModel.getCla());
+        ninjaDTO.setRank(ninjaModel.getRank());
+        ninjaDTO.setTecnicas(ninjaModel.getTecnicas());
+        ninjaDTO.setMissoes(ninjaModel.getMissoes());
+
+        return ninjaDTO;
+    }
 }

--- a/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaMapper.java
+++ b/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaMapper.java
@@ -1,0 +1,4 @@
+package dev.javath.cadastroNinjas.Ninjas;
+
+public class NinjaMapper {
+}

--- a/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaService.java
+++ b/cadastroNinjas/src/main/java/dev/javath/cadastroNinjas/Ninjas/NinjaService.java
@@ -4,33 +4,47 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class NinjaService {
     private NinjaRepository ninjaRepository;
+    private NinjaMapper ninjaMapper;
 
-    public NinjaService(NinjaRepository ninjaRepository) {
+    public NinjaService(NinjaRepository ninjaRepository, NinjaMapper ninjaMapper) {
         this.ninjaRepository = ninjaRepository;
+        this.ninjaMapper = ninjaMapper;
     }
 
-    public NinjaModel criarNinja(NinjaModel ninja){
-        return ninjaRepository.save(ninja);
+    public NinjaDTO criarNinja(NinjaDTO ninjaDTO){
+        System.out.println("DTO Recebido: " + ninjaDTO.getNome() + ", " + ninjaDTO.getCla());
+        NinjaModel ninja = new NinjaMapper().map(ninjaDTO);
+        System.out.println("Model Antes do Save: " + ninja.getNome() + ", " + ninja.getCla());
+        ninja = ninjaRepository.save(ninja);
+        return ninjaMapper.map(ninja);
     }
 
-    public List<NinjaModel> mostrarTodosOsNinjas(){
-       return ninjaRepository.findAll();
+    public List<NinjaDTO> mostrarTodosOsNinjas(){
+       List<NinjaModel> ninjas = ninjaRepository.findAll();
+       return ninjas.stream()
+               .map(ninjaMapper::map)
+               .collect(Collectors.toList());
     }
 
-    public Optional<NinjaModel> mostrarNinjaPorId(Long id) {
-        return ninjaRepository.findById(id);
+    public NinjaDTO mostrarNinjaPorId(Long id) {
+        Optional<NinjaModel> ninjaPorId = ninjaRepository.findById(id);
+        return ninjaPorId.map(ninjaMapper::map).orElse(null);
     }
-    public NinjaModel atualizarNinjaPorId(Long id, NinjaModel ninjaAtualizado){
-        if (ninjaRepository.existsById(id)){
+
+    public NinjaDTO atualizarNinjaPorId(Long id, NinjaDTO ninjaDTO){
+        Optional<NinjaModel> ninjaEncontrado = ninjaRepository.findById(id);
+        if (ninjaEncontrado.isPresent()){
+            NinjaModel ninjaAtualizado = ninjaMapper.map(ninjaDTO);
             ninjaAtualizado.setId(id);
-            return ninjaRepository.save(ninjaAtualizado);
-        } else {
-            return null;
+            NinjaModel ninjaSalvo =  ninjaRepository.save(ninjaAtualizado);
+            return ninjaMapper.map(ninjaSalvo);
         }
+        return null;
     }
 
     public void deletarNinjaPorId(Long id){


### PR DESCRIPTION
Alterações proposta pelo PR

Implementação do ninjaMapper para conversão entre ninjaModel e ninjaDTO.
Criação do ninjaDTO contendo os campos necessarios para comunição externa.
Refatoração do ninjaService para utilizar o ninjaDTO, eliminando a exposição direta do ninjaModel.
Refatoração do ninjaController para trabalhar com  ninjaDTO, garantindo uma estrutura mais coesa e desacoplada.

essas mudanças visam melhorar a organização do codigo e a separação de responsabilidades, facilitando a manutenção e possivel expansão da apalicação